### PR TITLE
Fix RuntimeError in aiohttp

### DIFF
--- a/aiohttp_wsgi/wsgi.py
+++ b/aiohttp_wsgi/wsgi.py
@@ -123,6 +123,7 @@ class WSGIHandler:
             # Close the body.
             if hasattr(body_iterable, "close"):
                 yield from self._run_in_executor(body_iterable.close)
+        return response._response
 
 
 class WSGIResponse:


### PR DESCRIPTION
Aiohttp expects a StreamResponse instance in its handle_request, and
will fail with a RuntimeError since aiohttp-wsgi currently returns
nothing to it:

RuntimeError: Handler <bound method _NotFoundMatchInfo._not_found of {}>
should return response instance, got <class 'NoneType'> [middlewares
(<function wsgi.<locals>.middleware_factory at 0x7f42f94d6620>,)]

This change simply returns the StreamResponse used internally to keep
aiohttp happy.

Signed-off-by: Slinky <slinky@iki.fi>