### PR TITLE
Upgrade aiohttp dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(
     url="https://github.com/etianen/aiohttp-wsgi",
     packages=find_packages(exclude=("tests",)),
     install_requires=[
-        "aiohttp>=0.22.2,<0.23",
+        "aiohttp>=0.22.2,<2",
     ],
     entry_points={
         "console_scripts": ["aiohttp-wsgi-serve=aiohttp_wsgi.__main__:main"],


### PR DESCRIPTION
`aiohttp-wsgi` is compatible with `aiohttp=1.0.2`.

Tested manually, also travis tests are passing: https://travis-ci.org/tahajahangir/aiohttp-wsgi/jobs/163407889