### PR TITLE
Use python3 for every tox env

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -8,6 +8,7 @@ envlist =
     docs
 
 [testenv]
+basepython = python3
 usedevelop = True
 deps =
     coverage>=4.1


### PR DESCRIPTION
As `python` refers to `python2` on many systems (see also [PEP 394][]), `coverage-erase` could be executed by Python 2 so that it fails.

[PEP 394]: https://www.python.org/dev/peps/pep-0394/