### PR TITLE
RAW_URI/REQUEST_URI for unquoted path

### DIFF
--- a/aiohttp_wsgi/wsgi.py
+++ b/aiohttp_wsgi/wsgi.py
@@ -229,6 +229,10 @@ class WSGIHandler:
             "REQUEST_METHOD": request.method,
             "SCRIPT_NAME": script_name,
             "PATH_INFO": path_info,
+            "RAW_URI": request.raw_path,
+            # RAW_URI: Gunicorn's non-standard field
+            "REQUEST_URI": request.raw_path,
+            # REQUEST_URI: uWSGI/Apache mod_wsgi's non-standard field
             "QUERY_STRING": request.rel_url.raw_query_string,
             "CONTENT_TYPE": request.headers.get("Content-Type", ""),
             "CONTENT_LENGTH": str(content_length),

--- a/tests/test_environ.py
+++ b/tests/test_environ.py
@@ -83,6 +83,13 @@ def assert_environ_root_subdir_trailing(environ):
     assert environ["PATH_INFO"] == "/bar"
 
 
+@environ_application
+def assert_environ_quoted_path_info(environ):
+    assert environ['PATH_INFO'] == "/테/스/트"
+    assert environ['RAW_URI'] == "/%ED%85%8C%2F%EC%8A%A4%2F%ED%8A%B8"
+    assert environ['REQUEST_URI'] == "/%ED%85%8C%2F%EC%8A%A4%2F%ED%8A%B8"
+
+
 class EnvironTest(AsyncTestCase):
 
     def testEnviron(self):
@@ -128,3 +135,7 @@ class EnvironTest(AsyncTestCase):
             "tests.test_environ:assert_environ_root_subdir_trailing"
         ) as client:
             client.assert_response(path="/foo/bar")
+
+    def testQuotedPathInfo(self):
+        with self.serve("tests.test_environ:assert_environ_quoted_path_info") as client:
+            client.assert_response(path="/%ED%85%8C%2F%EC%8A%A4%2F%ED%8A%B8")


### PR DESCRIPTION
This patch adds non-standard fields named `RAW_URI` and `REQUEST_URI` to WSGI `environ`.  This solves the following problem.

According to [PEP 3333][], WSGI requires to unquote `PATH_INFO` before it's passed to an application, as CGI did.  Unfortunately, it makes some unrecoverable loss of its raw request from a client.

For example, if a request was `GET /A%2FB`, the `%2F` sequence is unquoted to `/A/B`.

There's one more difficulty about `PATH_INFO` when it comes to Python 3. As WSGI's `PATH_INFO` environ should be a Unicode `str`, percent-encoded sequence (which is encoding of bytes, rather than Unicode characters) needs to be *interpreted* in a certain encoding — aiohttp-wsgi indeed interprets them in UTF-8 encoding.  It means that if a client requests a path containing some bytes encoded in non-UTF-8 the requested path (e.g. `/%ED%85%8C%2F%EC%8A%A4%2F%ED%8A%B8`) will be lost in an unrecoverable way.

Further reading: [WSGI Amendments thoughts: the horror of charsets](https://www.mail-archive.com/web-sig@python.org/msg02483.html) (Web-SIG).

Since this problem has been quite well known to WSGI implementers, several widely-used WSGI servers provide some non-standard workarounds. uWSGI and [Apache mod_wsgi provides `REQUEST_URI`][1]. [Gunicorn provides `RAW_URI`.][2]  These fields contain a untouched and uninterpreted path string.  Some WSGI frameworks or applications use it (though they fallback to `PATH_INFO` if these fields don't exist).  This patch chose these field names rather than introducing yet another non-standard field.

[PEP 3333]: https://www.python.org/dev/peps/pep-3333/
[1]: https://groups.google.com/d/msg/modwsgi/R5Lmqg98VvQ/pLVtwmD57IsJ
[2]: https://github.com/benoitc/gunicorn/issues/1161#issuecomment-164279284