### PR TITLE
Add support for aiohttp >= 3.4 and Python 3.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,8 @@ env:
     - PYTHONASYNCIODEBUG=1
 matrix:
   fast_finish: true
+  include:
+    - { python: "3.7", dist: xenial, sudo: true }
 install:
   - pip install flake8 coverage sphinx -e .
 script:

--- a/aiohttp_wsgi/wsgi.py
+++ b/aiohttp_wsgi/wsgi.py
@@ -92,7 +92,6 @@ import asyncio
 import logging
 import os
 import sys
-from asyncio import get_event_loop
 from concurrent.futures import ThreadPoolExecutor
 from contextlib import contextmanager
 from tempfile import SpooledTemporaryFile
@@ -176,7 +175,7 @@ class WSGIHandler:
         self._max_request_body_size = max_request_body_size
         # asyncio config.
         self._executor = executor
-        self._loop = loop or get_event_loop()
+        self._loop = loop or asyncio.get_event_loop()
 
     def _get_environ(self, request, body, content_length):
         # Resolve the path info.

--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,8 @@ setup(
         "Programming Language :: Python",
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3.5",
+        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
         "Framework :: Django",
     ],
 )

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,6 @@ setup(
         "Operating System :: OS Independent",
         "Programming Language :: Python",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.4",
         "Programming Language :: Python :: 3.5",
         "Framework :: Django",
     ],


### PR DESCRIPTION
The failure of the tests is unrelated to this PR and I haven't found a simple solution to fix them:

> docstring of aiohttp_wsgi.wsgi:68:py:class reference target not found: asyncio.BaseEventLoop