### PR TITLE
Fix typo in README: aiottp => aiohttp

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -3,7 +3,7 @@ aiohttp-wsgi
 
 WSGI adapter for `aiohttp <http://aiohttp.readthedocs.io/en/stable/web.html>`_.
 
-**aiottp-wsgi** is actively maintained and used in prodution, with any bug reports or feature requests answered promptly. It's a small, stable library, so can go a long time without new releases or updates!
+**aiohttp-wsgi** is actively maintained and used in prodution, with any bug reports or feature requests answered promptly. It's a small, stable library, so can go a long time without new releases or updates!
 
 .. image:: https://travis-ci.org/etianen/aiohttp-wsgi.svg?branch=master
     :target: https://travis-ci.org/etianen/aiohttp-wsgi


### PR DESCRIPTION
Fix typo in README: aiottp => aiohttp.
