### PR TITLE
Added power support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 sudo: false
 language: python
+arch:
+  - AMD64
+  - ppc64le
 python:
   - 3.6
   - 3.5
@@ -12,6 +15,7 @@ matrix:
   fast_finish: true
   include:
     - { python: "3.7", dist: xenial, sudo: true }
+    - { python: "3.7", dist: xenial, sudo: true, arch: ppc64le }
 install:
   - pip install flake8 coverage sphinx -e .
 script:


### PR DESCRIPTION
Added power support for the travis.yml file with ppc64le. This is part of the Ubuntu distribution for ppc64le. This helps us simplify testing later when distributions are re-building and re-releasing. For more info tag @gerrith3.