### PR TITLE
fix quote-preservation in QUERY_STRING

### DIFF
--- a/aiohttp_wsgi/wsgi.py
+++ b/aiohttp_wsgi/wsgi.py
@@ -93,6 +93,7 @@ from io import BytesIO
 import logging
 import os
 import sys
+import urllib.parse
 from concurrent.futures import Executor, ThreadPoolExecutor
 from contextlib import contextmanager
 from tempfile import SpooledTemporaryFile
@@ -238,7 +239,8 @@ class WSGIHandler:
             # RAW_URI: Gunicorn's non-standard field
             "REQUEST_URI": request.raw_path,
             # REQUEST_URI: uWSGI/Apache mod_wsgi's non-standard field
-            "QUERY_STRING": request.rel_url.raw_query_string,
+            # We cannot use the raw_query_string from yarl, because it isn't raw.
+            "QUERY_STRING": urllib.parse.urlsplit(request.raw_path).query,
             "CONTENT_TYPE": request.headers.get("Content-Type", ""),
             "CONTENT_LENGTH": str(content_length),
             "SERVER_NAME": server_name,


### PR DESCRIPTION
QUERY_STRING is supposed to be faithful to the transmitted value. If one 
requests e.g. /?!%21, the QUERY_STRING should preserve both the unquoted 
and the quoted exclamation mark. Doing otherwise breaks digest
authentication in e.g. a WSGI middleware.

We cannot use yarl here as preserving the original representation is a 
non-goal for yarl. We must resort to re-parsing the raw_path.

Link: https://github.com/aio-libs/yarl/issues/498
Signed-off-by: Helmut Grohne <helmut.grohne@intenta.de>