### PR TITLE
Fix test to work with aiohttp 3.8.1+

### DIFF
--- a/tests/test_environ.py
+++ b/tests/test_environ.py
@@ -20,7 +20,7 @@ def assert_environ(environ: WSGIEnviron) -> None:
     assert environ["REQUEST_METHOD"] == "GET"
     assert environ["SCRIPT_NAME"] == ""
     assert environ["PATH_INFO"] == "/"
-    assert environ["CONTENT_TYPE"] == ""
+    assert environ["CONTENT_TYPE"] == "application/octet-stream"
     assert environ["CONTENT_LENGTH"] == "0"
     assert environ["SERVER_NAME"] == "127.0.0.1"
     assert int(environ["SERVER_PORT"]) > 0
@@ -97,6 +97,7 @@ class EnvironTest(AsyncTestCase):
     def testEnviron(self) -> None:
         with self.run_server(assert_environ) as client:
             client.assert_response(headers={
+                "Content-Type": "application/octet-stream",
                 "Foo": "bar",
             })
 


### PR DESCRIPTION
Fixes #32

I'm not sure this is a bug but rather a sane modification to aiohttp to add default Content-Type headers as `application/octet-stream`. Throughout the tests in both aiohttp server & client it's asserted to be `application/octet-stream` when unset. This change was made upstream [here](https://github.com/aio-libs/aiohttp/pull/1124).

I've opted to patch the tests here by adopting this convention of using `application/octet-stream` but also specifying it explicitly so that it still works with older versions.