### PR TITLE
Use get_event_loop at call-site when not set

### DIFF
--- a/aiohttp_wsgi/wsgi.py
+++ b/aiohttp_wsgi/wsgi.py
@@ -206,7 +206,7 @@ class WSGIHandler:
         self._max_request_body_size = max_request_body_size
         # asyncio config.
         self._executor = executor
-        self._loop = loop or asyncio.get_event_loop()
+        self._loop = loop
 
     def _get_environ(self, request: Request, body: IO[bytes], content_length: int) -> WSGIEnviron:
         # Resolve the path info.
@@ -291,7 +291,8 @@ class WSGIHandler:
             body.seek(0)
             # Get the environ.
             environ = self._get_environ(request, body, content_length)
-            return await self._loop.run_in_executor(
+            loop = self._loop or asyncio.get_event_loop()
+            return await loop.run_in_executor(
                 self._executor,
                 _run_application,
                 self._application,

--- a/tests/test_environ.py
+++ b/tests/test_environ.py
@@ -35,7 +35,6 @@ def assert_environ(environ: WSGIEnviron) -> None:
     assert environ["wsgi.multithread"]
     assert not environ["wsgi.multiprocess"]
     assert not environ["wsgi.run_once"]
-    assert isinstance(environ["asyncio.loop"], asyncio.BaseEventLoop)
     assert isinstance(environ["asyncio.executor"], ThreadPoolExecutor)
     assert "aiohttp.request" in environ
 


### PR DESCRIPTION
Maybe you have a better idea of how to fix this but the newer version of aiohttp gives me this error:

```
RuntimeError: Task <Task pending name='Task-21' coro=<RequestHandler._handle_request() running at /home/u8sand/.local/lib/python3.10/site-packages/aiohttp/web_protocol.py:435> cb=[Task.task_wakeup()]> got Future <Future pending cb=[_chain_future.<locals>._call_check_cancel() at /usr/lib/python3.10/asyncio/futures.py:384]> attached to a different loop
INFO:aiohttp.access:127.0.0.1 [15/Feb/2022:14:52:50 +0000] "GET / HTTP/1.1" 302 199 "-" "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/98.0.4758.80 Safari/537.36"
Traceback (most recent call last):
  File "/home/u8sand/Programs/work/active/appyter/appyter/render/flask_app/__init__.py", line 59, in error_handler
    return await handler(request)
  File "/home/u8sand/.local/lib/python3.10/site-packages/aiohttp/web_urldispatcher.py", line 197, in handler_wrapper
    return await result
  File "/home/u8sand/.local/lib/python3.10/site-packages/aiohttp_wsgi/wsgi.py", line 294, in handle_request
    return await self._loop.run_in_executor(
```

I assume this means that somehow aiohttp is using a different event loop during request handling. The easiest way I found to fix this was just to use `asyncio.get_event_loop()` in the request handler, rather than running it at initialization. I opted to preserve the loop option and use it if explicitly specified but fall back to determining the loop at the call-site. This should preserve backwards compatibility while fixing this particular issue.